### PR TITLE
fix: new issues should ping a team that exists

### DIFF
--- a/.github/workflows/new-issue-automation.yml
+++ b/.github/workflows/new-issue-automation.yml
@@ -19,7 +19,7 @@ jobs:
             $URL \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
-            --data '{ "body": "Thanks for your submission, @openedx/open-edx-project-managers will review shortly." }'
+            --data '{ "body": "Thanks for your submission, @openedx/openedx-product-managers will review shortly." }'
 
 # For future Slack alerting
       # - name: Alert in Slack


### PR DESCRIPTION
When a new issue is made in this repo, there is an automated message that pings a team. The team it is currently pinging does not exist. Does it make sense to ping https://github.com/orgs/openedx/teams/openedx-product-managers instead?